### PR TITLE
Minor esp32 fixes (#2837)

### DIFF
--- a/components/base_nodemcu/uart.c
+++ b/components/base_nodemcu/uart.c
@@ -20,9 +20,11 @@ bool uart_on_data_cb(unsigned id, const char *buf, size_t len){
   if(!gL)
     return false;
 
+  int top = lua_gettop(gL);
   lua_rawgeti(gL, LUA_REGISTRYINDEX, uart_status[id].receive_rf);
   lua_pushlstring(gL, buf, len);
   lua_pcall(gL, 1, 0, 0);
+  lua_settop(gL, top);
   return !run_input;
 }
 
@@ -34,9 +36,11 @@ bool uart_on_error_cb(unsigned id, const char *buf, size_t len){
   if(!gL)
     return false;
 
+  int top = lua_gettop(gL);
   lua_rawgeti(gL, LUA_REGISTRYINDEX, uart_status[id].error_rf);
   lua_pushlstring(gL, buf, len);
   lua_pcall(gL, 1, 0, 0);
+  lua_settop(gL, top);
   return true;
 }
 

--- a/components/task/task.c
+++ b/components/task/task.c
@@ -55,7 +55,7 @@ task_handle_t task_get_id(task_callback_t t) {
 }
 
 
-bool task_post (task_prio_t priority, task_handle_t handle, task_param_t param)
+bool IRAM_ATTR task_post (task_prio_t priority, task_handle_t handle, task_param_t param)
 {
   if (priority >= TASK_PRIORITY_COUNT ||
       (handle & TASK_HANDLE_MASK) != TASK_HANDLE_MONIKER)


### PR DESCRIPTION
* Move task_post() into IRAM so it can be used by IRAM'd ISRs.

* Don't leave crud on stack on pcall error.

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is for the `dev` branch rather than for `master`.
- [ ] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rationale behind this PR\>
